### PR TITLE
Fix and split integration tests related to jdbcoracle#8

### DIFF
--- a/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/MultipleSchemasIT.java
+++ b/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/MultipleSchemasIT.java
@@ -9,7 +9,6 @@ import ch.admin.bar.siard2.cmd.utils.siard.model.utils.Id;
 import ch.admin.bar.siard2.cmd.utils.siard.model.utils.QualifiedTableId;
 import lombok.val;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.OracleContainer;
@@ -17,11 +16,12 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-// tests restrictions to multiple schemas and checks support for packages with overloaded procedures
-public class SchemaPackagesIT {
+// tests download of multiple schemas
+public class MultipleSchemasIT {
     @Rule
     public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
 
@@ -29,12 +29,11 @@ public class SchemaPackagesIT {
     public final OracleContainer db = new OracleContainer("gvenzl/oracle-xe:21-slim-faststart")
             .withLogConsumer(new ConsoleLogConsumer())
             .withCopyFileToContainer(
-                    MountableFile.forHostPath(TestResourcesResolver.resolve(SqlScripts.Oracle.SCHEMA_PACKAGES)
+                    MountableFile.forHostPath(TestResourcesResolver.resolve(SqlScripts.Oracle.MULTPLE_SCHEMAS)
                                                                    .toPath()),
                     "/container-entrypoint-initdb.d/00_create_schemas.sql");
 
-    @Ignore //TODO: Investigate why this test passes despite reverting to jdbcoracle without BAZG-Quickfix
-    @Test
+    @Test(expected = SQLSyntaxErrorException.class)
     public void download_as_testuser() throws IOException, SQLException, ClassNotFoundException {
         // given
         val actualArchive = siardArchivesHandler.prepareEmpty();
@@ -66,7 +65,5 @@ public class SchemaPackagesIT {
                                                                   .tableId(Id.of("SIMPLE_TABLE"))
                                                                   .build()))
                 .isNotPresent();
-
-
     }
 }

--- a/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/MultipleSchemasIT.java
+++ b/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/MultipleSchemasIT.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 // tests download of multiple schemas
 public class MultipleSchemasIT {
+
     @Rule
     public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
 
@@ -33,8 +34,9 @@ public class MultipleSchemasIT {
                                                                    .toPath()),
                     "/container-entrypoint-initdb.d/00_create_schemas.sql");
 
+    // due to non-resolved issue https://github.com/sfa-siard/JdbcOracle/issues/8 expect an exception instead of ignoring the test.
     @Test(expected = SQLSyntaxErrorException.class)
-    public void download_as_testuser() throws IOException, SQLException, ClassNotFoundException {
+    public void download() throws IOException, SQLException, ClassNotFoundException {
         // given
         val actualArchive = siardArchivesHandler.prepareEmpty();
 

--- a/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/PackagesIT.java
+++ b/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/PackagesIT.java
@@ -1,0 +1,49 @@
+package ch.admin.bar.siard2.cmd.oracle.issues.jdbcoracle6;
+
+import ch.admin.bar.siard2.cmd.SiardFromDb;
+import ch.admin.bar.siard2.cmd.utils.ConsoleLogConsumer;
+import ch.admin.bar.siard2.cmd.utils.SqlScripts;
+import ch.admin.bar.siard2.cmd.utils.TestResourcesResolver;
+import ch.admin.bar.siard2.cmd.utils.siard.SiardArchivesHandler;
+import lombok.val;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+public class PackagesIT {
+
+    @Rule
+    public SiardArchivesHandler siardArchivesHandler = new SiardArchivesHandler();
+
+    @Rule
+    public final OracleContainer db = new OracleContainer("gvenzl/oracle-xe:21-slim-faststart")
+            .withLogConsumer(new ConsoleLogConsumer())
+            .withCopyFileToContainer(
+                    MountableFile.forHostPath(TestResourcesResolver.resolve(SqlScripts.Oracle.PACKAGE)
+                                                                   .toPath()),
+                    "/container-entrypoint-initdb.d/00_create_package.sql");
+
+    @Test(expected = IOException.class)
+    public void download() throws IOException, SQLException, ClassNotFoundException {
+        // given
+        val actualArchive = siardArchivesHandler.prepareEmpty();
+
+        // when
+        SiardFromDb siardFromDb = new SiardFromDb(new String[]{
+                "-o",
+                "-j:" + db.getJdbcUrl(),
+                "-u:" + "testuser",
+                "-p:" + "testpassword",
+                "-s:" + actualArchive.getPathToArchiveFile()
+        });
+
+        // then
+        Assert.assertEquals(SiardFromDb.iRETURN_OK, siardFromDb.getReturn());
+
+    }
+}

--- a/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/PackagesIT.java
+++ b/src/integrationTest/java/ch/admin/bar/siard2/cmd/oracle/issues/jdbcoracle6/PackagesIT.java
@@ -15,6 +15,7 @@ import org.testcontainers.utility.MountableFile;
 import java.io.IOException;
 import java.sql.SQLException;
 
+// tests download of oracle db with a package/ an overloaded function
 public class PackagesIT {
 
     @Rule
@@ -28,6 +29,7 @@ public class PackagesIT {
                                                                    .toPath()),
                     "/container-entrypoint-initdb.d/00_create_package.sql");
 
+    // due to non-resolved issue https://github.com/sfa-siard/JdbcOracle/issues/8 expect an exception instead of ignoring the test.
     @Test(expected = IOException.class)
     public void download() throws IOException, SQLException, ClassNotFoundException {
         // given
@@ -44,6 +46,5 @@ public class PackagesIT {
 
         // then
         Assert.assertEquals(SiardFromDb.iRETURN_OK, siardFromDb.getReturn());
-
     }
 }

--- a/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
+++ b/src/integrationTest/java/ch/admin/bar/siard2/cmd/utils/SqlScripts.java
@@ -5,7 +5,8 @@ public class SqlScripts {
         public final static String CREATE_USER_WITH_ALL_PRIVILEGES = "oracle/00_create_user.sql";
         public final static String JDBCBASE_7 = "oracle/issues/jdbcbase7/jdbcbase7.sql";
         public final static String SIARDCMD_15 = "oracle/issues/siardcmd15/siardcmd_15.sql";
-        public final static String SCHEMA_PACKAGES = "oracle/issues/jdbcoracle6/schema-packages.sql";
+        public final static String MULTPLE_SCHEMAS = "oracle/issues/jdbcoracle6/multiple-schemas.sql";
+        public static final String PACKAGE = "oracle/issues/jdbcoracle6/package.sql";
     }
 
     public static class Postgres {

--- a/src/integrationTest/resources/oracle/issues/jdbcoracle6/multiple-schemas.sql
+++ b/src/integrationTest/resources/oracle/issues/jdbcoracle6/multiple-schemas.sql
@@ -1,22 +1,11 @@
 ALTER SESSION SET CONTAINER=XEPDB1;
--- ====================================
--- 1. Create Users
--- ====================================
+
 CREATE USER testuser IDENTIFIED BY testpassword;
 CREATE USER otheruser IDENTIFIED BY otherpassword;
 
 GRANT CREATE SESSION, CREATE TABLE, CREATE TYPE, CREATE PROCEDURE TO testuser;
 GRANT CREATE SESSION, CREATE TABLE, CREATE TYPE, CREATE PROCEDURE TO otheruser;
 
--- Optionally allow them to store data
--- GRANT UNLIMITED TABLESPACE TO testuser;
--- GRANT UNLIMITED TABLESPACE TO otheruser;
-
--- ====================================
--- 2. Create Objects in OTHERUSER schema
--- ====================================
-
--- Connect to otheruser (or use CURRENT_SCHEMA if running from sys)
 ALTER SESSION SET CURRENT_SCHEMA = otheruser;
 
 CREATE TABLE simple_table (
@@ -31,4 +20,7 @@ CREATE TABLE simple_table (
                               value VARCHAR2(100)
 );
 
+-- the following grant is the reason for the expected exception in ch.admin.bar.siard2.cmd.oracle.issues.jdbcoracle6.MultipleSchemasIT.download
+-- the testuser has no permission to read otheruser.simple_table, causing the download to fail with the following error:
+-- ORA-01031: insufficient privileges
 GRANT INSERT ON otheruser.simple_table TO testuser;

--- a/src/integrationTest/resources/oracle/issues/jdbcoracle6/multiple-schemas.sql
+++ b/src/integrationTest/resources/oracle/issues/jdbcoracle6/multiple-schemas.sql
@@ -31,10 +31,4 @@ CREATE TABLE simple_table (
                               value VARCHAR2(100)
 );
 
-CREATE OR REPLACE PACKAGE overload_demo AS
-  PROCEDURE log_msg(p_msg VARCHAR2);
-  PROCEDURE log_msg(p_msg VARCHAR2, p_level NUMBER);
-  PROCEDURE log_msg(p_msg VARCHAR2, p_level NUMBER, p_user VARCHAR2);
-END overload_demo;
-
-GRANT INSERT ON otheruser.simple_table TO testuser; -- INSERT instead of SELECT
+GRANT INSERT ON otheruser.simple_table TO testuser;

--- a/src/integrationTest/resources/oracle/issues/jdbcoracle6/package.sql
+++ b/src/integrationTest/resources/oracle/issues/jdbcoracle6/package.sql
@@ -3,6 +3,7 @@ ALTER
 
 CREATE
     USER testuser IDENTIFIED BY testpassword;
+
 GRANT CREATE
     SESSION, CREATE TABLE, CREATE TYPE, CREATE PROCEDURE TO testuser;
 
@@ -11,16 +12,20 @@ ALTER
     SESSION SET CURRENT_SCHEMA = testuser;
 
 
+-- at least one table is required - otherwise the archive step will fail
 CREATE TABLE simple_table
 (
     id    NUMBER,
     value VARCHAR2(100)
 );
 
+-- oracles packages, overloaded functions are currently not supported causing the exception with the following error:
+-- java.io.IOException: Only one view with the same name allowed per schema!
+-- note that the error message is misleading due to a copy paste error
 CREATE
-    OR REPLACE PACKAGE overload_demo AS
+    OR REPLACE PACKAGE log_msg_overloaded AS
     PROCEDURE log_msg(p_msg VARCHAR2);
     PROCEDURE log_msg(p_msg VARCHAR2, p_level NUMBER);
     PROCEDURE log_msg(p_msg VARCHAR2, p_level NUMBER, p_user VARCHAR2);
-END overload_demo;
+END log_msg_overloaded;
 /

--- a/src/integrationTest/resources/oracle/issues/jdbcoracle6/package.sql
+++ b/src/integrationTest/resources/oracle/issues/jdbcoracle6/package.sql
@@ -1,0 +1,26 @@
+ALTER
+    SESSION SET CONTAINER=XEPDB1;
+
+CREATE
+    USER testuser IDENTIFIED BY testpassword;
+GRANT CREATE
+    SESSION, CREATE TABLE, CREATE TYPE, CREATE PROCEDURE TO testuser;
+
+
+ALTER
+    SESSION SET CURRENT_SCHEMA = testuser;
+
+
+CREATE TABLE simple_table
+(
+    id    NUMBER,
+    value VARCHAR2(100)
+);
+
+CREATE
+    OR REPLACE PACKAGE overload_demo AS
+    PROCEDURE log_msg(p_msg VARCHAR2);
+    PROCEDURE log_msg(p_msg VARCHAR2, p_level NUMBER);
+    PROCEDURE log_msg(p_msg VARCHAR2, p_level NUMBER, p_user VARCHAR2);
+END overload_demo;
+/


### PR DESCRIPTION
The integration tests related to jdbcoracle#8 had some errors in the setup, causing the tests to be green even though the fix itself was reverted. This was fixed in this PR.

Additionally, the IT was split in order to reproduce both issues independently. This allows isolated fixes for both issues.